### PR TITLE
Revert "Add jenkins permission to write Congitive services role assigments"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This respository is responsible for the creation of CFT Jenkins infrastructure u
 | [azurerm_key_vault_access_policy.infra_vault](https://registry.terraform.io/providers/hashicorp/azurerm/4.37.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_role_assignment.additional_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/4.37.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.aks_cluster_admin](https://registry.terraform.io/providers/hashicorp/azurerm/4.37.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cognitive_services_roles](https://registry.terraform.io/providers/hashicorp/azurerm/4.37.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.contributor](https://registry.terraform.io/providers/hashicorp/azurerm/4.37.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.monitoring_reader](https://registry.terraform.io/providers/hashicorp/azurerm/4.37.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.private_dns_zone_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/4.37.0/docs/resources/role_assignment) | resource |
@@ -64,7 +63,6 @@ This respository is responsible for the creation of CFT Jenkins infrastructure u
 | <a name="input_key_vaults"></a> [key\_vaults](#input\_key\_vaults) | Map of key vaults to which the managed identity should be granted access, keyed by an arbitrary name. Each value should be an object with 'name' and 'resource\_group\_name' properties. | <pre>map(object({<br/>    name                = string<br/>    resource_group_name = string<br/>  }))</pre> | `{}` | no |
 | <a name="input_location"></a> [location](#input\_location) | Azure location for the managed identity. | `string` | `"UK South"` | no |
 | <a name="input_manage_aks_cluster_admin_role"></a> [manage\_aks\_cluster\_admin\_role](#input\_manage\_aks\_cluster\_admin\_role) | Whether to manage the AKS Cluster Admin subscription role assignment. | `bool` | `true` | no |
-| <a name="input_manage_cognitive_services_roles"></a> [manage\_cognitive\_services\_roles](#input\_manage\_cognitive\_services\_roles) | Whether to manage the delegated Cognitive Services User / Cognitive Services OpenAI User role assignments. | `bool` | `true` | no |
 | <a name="input_manage_contributor_role"></a> [manage\_contributor\_role](#input\_manage\_contributor\_role) | Whether to manage the Contributor subscription role assignment. | `bool` | `true` | no |
 | <a name="input_manage_reader_role"></a> [manage\_reader\_role](#input\_manage\_reader\_role) | Whether to manage the Reader subscription role assignment. | `bool` | `true` | no |
 | <a name="input_managed_identity_name"></a> [managed\_identity\_name](#input\_managed\_identity\_name) | Managed identity name. | `string` | n/a | yes |

--- a/components/jenkins-agent-identities/main.tf
+++ b/components/jenkins-agent-identities/main.tf
@@ -182,32 +182,3 @@ resource "azurerm_role_assignment" "rbac_administrator" {
     )
   EOT
 }
-
-// For AI Gateway onboarding requirement, supports Cognitive Services User and Cognitive Services OpenAI User roles
-resource "azurerm_role_assignment" "cognitive_services_roles" {
-  count = var.manage_cognitive_services_roles ? 1 : 0
-
-  scope = "/subscriptions/${var.subscription_id}"
-  name = uuidv5(
-    "url",
-    "Cognitive Services Roles:/subscriptions/${var.subscription_id}:${local.principal_id}"
-  )
-  role_definition_name = "Role Based Access Control Administrator"
-  principal_id          = local.principal_id
-  condition_version     = "2.0"
-  condition             = <<-EOT
-    (
-      !(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})
-      OR
-      @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId]
-        ForAnyOfAnyValues:GuidEquals {a97b65f3-24c7-4388-baec-6cadf0d69793, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
-    )
-    AND
-    (
-      !(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})
-      OR
-      @Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId]
-        ForAnyOfAnyValues:GuidEquals {a97b65f3-24c7-4388-baec-6cadf0d69793, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
-    )
-  EOT
-}

--- a/components/jenkins-agent-identities/main.tf
+++ b/components/jenkins-agent-identities/main.tf
@@ -171,14 +171,14 @@ resource "azurerm_role_assignment" "rbac_administrator" {
       !(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})
       OR
       @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId]
-        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7}
+        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, a97b65f3-24c7-4388-baec-6cadf0d69793, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
     )
     AND
     (
       !(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})
       OR
       @Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId]
-        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7}
+        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, a97b65f3-24c7-4388-baec-6cadf0d69793, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
     )
   EOT
 }

--- a/components/jenkins-agent-identities/variables.tf
+++ b/components/jenkins-agent-identities/variables.tf
@@ -105,9 +105,3 @@ variable "alerts_subscription_id" {
   type        = string
   default     = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 }
-
-variable "manage_cognitive_services_roles" {
-  description = "Whether to manage the delegated Cognitive Services User / Cognitive Services OpenAI User role assignments."
-  type        = bool
-  default     = true
-}


### PR DESCRIPTION
Reverts hmcts/cft-jenkins-infrastructure#87 - pipeline fails with resource conflict because the principal/scope/role are the same, this needs adding to the existing roles condition

Have added the Cognitive Services roles to the existing condition of the RBAC role instead