### PR TITLE
Correct Cognitive Services User role GUID

### DIFF
--- a/components/jenkins-agent-identities/main.tf
+++ b/components/jenkins-agent-identities/main.tf
@@ -171,14 +171,14 @@ resource "azurerm_role_assignment" "rbac_administrator" {
       !(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})
       OR
       @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId]
-        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, a97b65f3-24c7-4388-baec-6cadf0d69793, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
+        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, aa97b65f3-24c7-4388-baec-2e87135dc908, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
     )
     AND
     (
       !(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})
       OR
       @Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId]
-        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, a97b65f3-24c7-4388-baec-6cadf0d69793, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
+        ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, a97b65f3-24c7-4388-baec-2e87135dc908, 5e0bd9bd-7b93-4f28-af87-19fc36ad61bd}
     )
   EOT
 }


### PR DESCRIPTION
Typo in one of the role IDs - based on https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles

should resolve https://sandbox-build.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c_Sandbox%2Fcnp-plum-shared-infrastructure/detail/master/9/pipeline/