### PR TITLE
DTSPO-34836: Expire Jenkins cache after 30 days

### DIFF
--- a/components/jenkins/artifacts-storage-account.tf
+++ b/components/jenkins/artifacts-storage-account.tf
@@ -26,6 +26,37 @@ resource "azurerm_storage_container" "job_cache" {
   container_access_type = "private"
 }
 
+data "azurerm_storage_account" "sandbox_job_cache" {
+  count = var.env == "ptlsbox" ? 1 : 0
+
+  provider            = azurerm.cache_storage
+  name                = "mgmtbuildlogstoresandbox"
+  resource_group_name = "mgmt-buildlog-store-sandbox"
+}
+
+resource "azurerm_storage_management_policy" "job_cache" {
+  count = contains(["ptl", "ptlsbox"], var.env) ? 1 : 0
+
+  provider           = azurerm.cache_storage
+  storage_account_id = var.env == "ptl" ? azurerm_storage_account.storage_account[0].id : data.azurerm_storage_account.sandbox_job_cache[0].id
+
+  rule {
+    name    = "delete-job-cache-after-30-days"
+    enabled = true
+
+    filters {
+      prefix_match = ["job-cache/"]
+      blob_types   = ["blockBlob"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 30
+      }
+    }
+  }
+}
+
 resource "azurerm_key_vault_secret" "job_cache_account_key" {
   count = var.env == "ptl" ? 1 : 0
 

--- a/components/jenkins/init.tf
+++ b/components/jenkins/init.tf
@@ -19,6 +19,13 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
+  alias                           = "cache_storage"
+  subscription_id                 = var.env == "ptlsbox" ? "bf308a5c-0624-4334-8ff8-8dca9fd43783" : var.subscription_id
+  resource_provider_registrations = "none"
+  features {}
+}
+
+provider "azurerm" {
   features {}
   skip_provider_registration = true
   alias                      = "postgres_network"
@@ -43,5 +50,3 @@ provider "azurerm" {
   skip_provider_registration = "true"
   features {}
 }
-
-


### PR DESCRIPTION
### Jira link

See [DTSPO-34836](https://tools.hmcts.net/jira/browse/DTSPO-34836)

### Change description

Adds a 30-day lifecycle policy for blobs in the `job-cache` container. Covers the CFT PTL storage account and the existing legacy sandbox cache account via a scoped cross-subscription provider.

### Testing done


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change